### PR TITLE
Creació del endpoint deleteActivity

### DIFF
--- a/BackendTFG/src/main/java/com/tecnocampus/backendtfg/api/ActivityRestController.java
+++ b/BackendTFG/src/main/java/com/tecnocampus/backendtfg/api/ActivityRestController.java
@@ -3,10 +3,7 @@ package com.tecnocampus.backendtfg.api;
 import com.tecnocampus.backendtfg.application.ActivityService;
 import com.tecnocampus.backendtfg.application.dto.ActivityDTO;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/activity")
 @RestController
@@ -22,6 +19,12 @@ public class ActivityRestController {
     public ResponseEntity<String> createActivity(@RequestBody ActivityDTO activityDTO,String email) {
         activityService.createActivity(activityDTO,email);
         return ResponseEntity.ok("Activity created");
+    }
+
+    @DeleteMapping("/deleteActivity")
+    public ResponseEntity<String> deleteActivity(@RequestBody ActivityDTO activityDTO,String email) {
+        activityService.deleteActivity(activityDTO,email);
+        return ResponseEntity.ok("Activity deleted");
     }
 
 }

--- a/BackendTFG/src/main/java/com/tecnocampus/backendtfg/application/ActivityService.java
+++ b/BackendTFG/src/main/java/com/tecnocampus/backendtfg/application/ActivityService.java
@@ -9,6 +9,8 @@ import com.tecnocampus.backendtfg.persistence.ActivityRepository;
 import com.tecnocampus.backendtfg.persistence.UserRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.Date;
+
 @Service
 public class ActivityService {
 
@@ -30,6 +32,15 @@ public class ActivityService {
         ActivityProfile activityProfile = user.getActivityProfile();
         Activity activity = new Activity(activityDTO,activityProfile);
         activityRepository.save(activity);
+        activityProfileRepository.save(activityProfile);
+    }
+
+    public void deleteActivity(ActivityDTO activityDTO,String email) {
+        User user = userRepository.findByEmail(email);
+        ActivityProfile activityProfile = user.getActivityProfile();
+        Date date = activityDTO.getDate();
+        Activity activity = activityRepository.findByDate(date);
+        activityRepository.delete(activity);
         activityProfileRepository.save(activityProfile);
     }
 }

--- a/BackendTFG/src/main/java/com/tecnocampus/backendtfg/persistence/ActivityRepository.java
+++ b/BackendTFG/src/main/java/com/tecnocampus/backendtfg/persistence/ActivityRepository.java
@@ -5,8 +5,10 @@ import com.tecnocampus.backendtfg.domain.Activity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Date;
+
 @Repository
 public interface ActivityRepository extends JpaRepository<Activity, Long> {
 
-
+    Activity findByDate(Date date);
 }

--- a/BackendTFG/src/test/java/com/tecnocampus/backendtfg/ActivityTests.java
+++ b/BackendTFG/src/test/java/com/tecnocampus/backendtfg/ActivityTests.java
@@ -14,11 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
-
 import java.util.Date;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 public class ActivityTests {
@@ -62,6 +58,36 @@ public class ActivityTests {
         // Assert
         Mockito.verify(userRepository, Mockito.times(1)).findByEmail(email);
         Mockito.verify(activityRepository, Mockito.times(1)).save(Mockito.any(Activity.class));
+        Mockito.verify(activityProfileRepository, Mockito.times(1)).save(Mockito.any(ActivityProfile.class));
+    }
+
+    @Test
+    public void deleteActivityTest() {
+        // Arrange
+        ActivityProfile activityProfile = new ActivityProfile();
+        User user = new User();
+        String email = "example@email.com";
+        user.setEmail(email);
+        user.setActivityProfile(activityProfile);
+
+        Date date = new Date();
+        ActivityDTO activityDTO = new ActivityDTO();
+        activityDTO.setDuration(1.5);
+        activityDTO.setDate(date);
+        activityDTO.setType(TypeActivity.RUNNING);
+        activityDTO.setDescription("Test Description");
+
+        Activity activity = new Activity(activityDTO, activityProfile);
+
+        Mockito.when(userRepository.findByEmail(email)).thenReturn(user);
+        Mockito.when(activityRepository.findByDate(date)).thenReturn(activity);
+
+        // Act
+        activityService.deleteActivity(activityDTO, email);
+
+        // Assert
+        Mockito.verify(userRepository, Mockito.times(1)).findByEmail(email);
+        Mockito.verify(activityRepository, Mockito.times(1)).delete(Mockito.any(Activity.class));
         Mockito.verify(activityProfileRepository, Mockito.times(1)).save(Mockito.any(ActivityProfile.class));
     }
 }


### PR DESCRIPTION
Descripció dels canvis realitzats:

**ActivityRestController.java**

Nou mètode deleteActivity: S’hi ha afegit un endpoint HTTP DELETE que rep l’ID de l’activitat a eliminar.
Gestió d’errors: Es llança una resposta adequada en cas que l’activitat no existeixi o hi hagi restriccions que impedeixin l’eliminació.

**ActivityService.java**

Mètode deleteActivity(UUID activityId): Implementa la lògica de negoci necessària per comprovar l’existència de l’activitat i autoritzar o refusar la seva eliminació.
Control d’excepcions: Permet retornar missatges o codis d’error rellevants al controlador quan es produeixen situacions anòmales (p. ex., activitat inexistent).

**ActivityRepository.java**

Eliminació de l’entitat Activity: Mètode que gestiona la supressió de la base de dades, tenint en compte relacions i referències creuades si escau.
Verificacions prèvies: Possibilitat d’incloure consultes addicionals per assegurar la coherència de dades.

**ActivityTests.java**

Proves unitàries i d’integració: Confirmen que el endpoint deleteActivity funciona correctament, tant en escenaris d’èxit (eliminació satisfactòria) com en escenaris d’error (activitat inexistent o altres dependències).

Resum:
Aquest pull request afegeix la funcionalitat per eliminar activitats del sistema, garantint que la petició arribi correctament al controlador, passi per la capa de servei amb la lògica corresponent i finalment suprimeixi la informació a la base de dades. També s’han inclòs proves per assegurar la qualitat i la coherència de la solució.