### PR TITLE
Creació del endpoint getActivities

### DIFF
--- a/BackendTFG/src/main/java/com/tecnocampus/backendtfg/api/ActivityRestController.java
+++ b/BackendTFG/src/main/java/com/tecnocampus/backendtfg/api/ActivityRestController.java
@@ -5,6 +5,7 @@ import com.tecnocampus.backendtfg.application.dto.ActivityDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+
 @RequestMapping("/activity")
 @RestController
 public class ActivityRestController {
@@ -30,6 +31,11 @@ public class ActivityRestController {
     public ResponseEntity<String> updateActivity(@RequestBody ActivityDTO activityDTO,String email) {
         activityService.updateActivity(activityDTO,email);
         return ResponseEntity.ok("Activity updated");
+    }
+
+    @GetMapping("/getActivities")
+    public ResponseEntity<?> getActivities(String email) {
+        return ResponseEntity.ok(activityService.getActivities(email));
     }
 
 }

--- a/BackendTFG/src/main/java/com/tecnocampus/backendtfg/application/ActivityService.java
+++ b/BackendTFG/src/main/java/com/tecnocampus/backendtfg/application/ActivityService.java
@@ -10,6 +10,8 @@ import com.tecnocampus.backendtfg.persistence.UserRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class ActivityService {
@@ -52,5 +54,13 @@ public class ActivityService {
         activity.update(activityDTO);
         activityRepository.save(activity);
         activityProfileRepository.save(activityProfile);
+    }
+
+    public List<ActivityDTO> getActivities(String email) {
+        User user = userRepository.findByEmail(email);
+        ActivityProfile activityProfile = user.getActivityProfile();
+        return activityProfile.getActivities().stream()
+                .map(ActivityDTO::new)
+                .toList();
     }
 }

--- a/BackendTFG/src/main/java/com/tecnocampus/backendtfg/application/dto/ActivityDTO.java
+++ b/BackendTFG/src/main/java/com/tecnocampus/backendtfg/application/dto/ActivityDTO.java
@@ -1,5 +1,6 @@
 package com.tecnocampus.backendtfg.application.dto;
 
+import com.tecnocampus.backendtfg.domain.Activity;
 import com.tecnocampus.backendtfg.domain.TypeActivity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,5 +22,12 @@ public class ActivityDTO {
         this.date = date;
         this.type = type;
         this.description = description;
+    }
+
+    public ActivityDTO(Activity activity) {
+        this.duration = activity.getDuration();
+        this.date = activity.getDate();
+        this.type = activity.getType();
+        this.description = activity.getDescription();
     }
 }

--- a/BackendTFG/src/test/java/com/tecnocampus/backendtfg/ActivityTests.java
+++ b/BackendTFG/src/test/java/com/tecnocampus/backendtfg/ActivityTests.java
@@ -15,6 +15,9 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 public class ActivityTests {
@@ -117,5 +120,30 @@ public class ActivityTests {
             Mockito.verify(activityRepository, Mockito.times(1)).findByDate(date);
             Mockito.verify(activityRepository, Mockito.times(1)).save(Mockito.any(Activity.class));
             Mockito.verify(activityProfileRepository, Mockito.times(1)).save(Mockito.any(ActivityProfile.class));
+    }
+
+    @Test
+    public void getActivitiesTest() {
+        // Arrange
+        ActivityProfile activityProfile = new ActivityProfile();
+        User user = new User();
+        String email = "example@email.com";
+        user.setEmail(email);
+        user.setActivityProfile(activityProfile);
+
+        Activity activity1 = new Activity(1.5, new Date(), TypeActivity.RUNNING, "Test Description 1", activityProfile);
+        Activity activity2 = new Activity(2.0, new Date(), TypeActivity.CYCLING, "Test Description 2", activityProfile);
+        activityProfile.setActivities(List.of(activity1, activity2));
+
+        Mockito.when(userRepository.findByEmail(email)).thenReturn(user);
+
+        // Act
+        List<ActivityDTO> activities = activityService.getActivities(email);
+
+        // Assert
+        Mockito.verify(userRepository, Mockito.times(1)).findByEmail(email);
+        assertEquals(2, activities.size());
+        assertEquals("Test Description 1", activities.get(0).getDescription());
+        assertEquals("Test Description 2", activities.get(1).getDescription());
     }
 }


### PR DESCRIPTION
**Pull Request: Creació del *endpoint* `getActivities`**

**Descripció dels canvis realitzats (commits i fitxers modificats):**

1. **`ActivityRestController.java`**  
   - **Nou mètode `getActivities`:** Endpoint REST (GET) que retorna una llista d’activitats des de la capa de serveis.  
   - **Paràmetres opcionals (si escau):** Possibilitat de filtrar o paginar resultats (dates, estat, etc.) segons els requisits del projecte.  
   - **Gestió d’errors:** Retorna missatges o codis d’estat adequats en cas d’absència d’activitats o problemes interns.

2. **`ActivityService.java`**  
   - **Mètode `getActivities()`:** Implementa la lògica de negoci per recuperar la llista d’activitats de la base de dades.  
   - **Tractament de dades:** Pot incloure validacions o conversions prèvies a retornar-les al controlador.

3. **`ActivityDTO.java`**  
   - **Objecte de transferència de dades:** S’utilitza per empaquetar i retornar la informació d’una activitat, assegurant la separació entre el model intern i la resposta REST.  
   - **Afegits o ajustos de camps:** S’hi pot incloure informació addicional (p. ex., dates, títol, descripció) per millorar la resposta al client.

4. **`ActivityTests.java`**  
   - **Proves unitaris i d’integració per a `getActivities`:** Validació del retorn d’activitats en escenaris d’èxit (hi ha activitats) i d’error (cap activitat, errors de connexió, etc.).  
   - **Garantia de qualitat:** Assegura que la funcionalitat compleix els requeriments i que el codi es comporta correctament davant diverses situacions.

---

**Resum**  
Aquest *pull request* introdueix el nou endpoint `getActivities`, que permet recuperar la llista d’activitats emmagatzemades. El controlador REST rep la petició, la capa de serveis gestiona la lògica de negoci i s’utilitzen *DTOs* per retornar les dades de manera neta i coherent. Les proves associades verifiquen el correcte funcionament i la robustesa de la solució. 